### PR TITLE
docs: update CHANGELOG and README for upstream reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Added
+
+- Default `permissions.allow` and `permissions.deny` rules in `settings.json` to reduce prompt friction
+- `/branch` skill for creating properly-named feature branches from `origin/main`
+- `/protect` skill for applying GitHub branch protection rulesets from `.github/ruleset.json`
+- `.github/workflows/ci.yml` scaffold with placeholder lint, test, and build jobs
+- `.github/ruleset.json` declarative branch protection config (squash-only, linear history, status checks)
+- `.github/pull_request_template.md` with Summary, Changes, Test Plan, and Notes sections
+- Git-Ops Workflow section in `CLAUDE.md` documenting multi-layer enforcement of feature-branch development
+- Auto-post review findings as PR comment via `gh pr comment` in `/review` skill
+- Main-branch warning in `context-loader.sh` at session start
+- `tool-policy.json` rules blocking direct push to main/master
+
+### Changed
+
+- Enhanced `/commit` skill with branch guard (refuses commit on main/master)
+- Enhanced `/pr` skill with branch guard, rebase freshness check, SSH alias workaround, and self-review suggestion
+- Improved Go linting in `post-edit-lint.sh` with go.mod directory discovery
+- Updated reviewer agent to include `gh pr comment` in allowed tools
+
+### Fixed
+
+- Fixed `audit-logger.sh` jq string slicing syntax (`tostring[:500]` → `tostring | .[0:500]`) and added stderr suppression
+- Fixed macOS-incompatible non-greedy regex in `/pr` skill sed command (`[^/]+?` → `[^/.]+`)
+
 ## [0.1.0] - 2026-02-06
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Hooks like `post-edit-lint.sh` and `affected-tests.sh` auto-detect common framew
 |-------|-------|---------|
 | `reader` | Read, Glob, Grep | Read-only codebase exploration |
 | `builder` | Read, Glob, Grep, Edit, Write, Bash, Task, NotebookEdit | Full implementation (no web access) |
-| `reviewer` | Read, Glob, Grep, git read commands | Code review without write access |
+| `reviewer` | Read, Glob, Grep, git read commands, gh pr comment | Code review with PR comment posting |
 | `researcher` | Read, Glob, Grep, WebSearch, WebFetch | Web + codebase research |
 
 Agents are defined in `.claude/agents/*.md`. Each file declares an `allowed_tools` list that Claude Code enforces at the platform level.
@@ -58,6 +58,8 @@ Agents are defined in `.claude/agents/*.md`. Each file declares an `allowed_tool
 | `/test` | fork &rarr; `builder` | Run tests and summarize results |
 | `/plan` | main | Interactive implementation planning |
 | `/pr` | main | Create or update pull requests via `gh` |
+| `/branch` | main | Create a feature branch from main |
+| `/protect` | main | Configure GitHub branch protection rulesets |
 | `/loop` | main | Iterative fix-and-check until a condition is met |
 | `/handoff` | main | Generate session handoff document |
 
@@ -115,12 +117,14 @@ Hooks are shell scripts configured in `.claude/settings.json`. They fire at Clau
     team-research.md      # Research team template
     team-review.md        # Review team template
   skills/
+    branch/SKILL.md
     changelog/SKILL.md
     commit/SKILL.md
     handoff/SKILL.md      # + template.md
     loop/SKILL.md
     plan/SKILL.md         # + template.md
     pr/SKILL.md
+    protect/SKILL.md
     review/SKILL.md       # + checklist.md
     test/SKILL.md
   settings.json           # Hook configuration + permissions
@@ -141,6 +145,10 @@ docs/
   CUSTOMIZATION.md        # How to adapt the template
   HOOKS.md                # Hook configuration and gotchas
   PATTERNS.md             # Multi-agent patterns and recipes
+.github/
+  pull_request_template.md  # PR template (Summary, Changes, Test Plan, Notes)
+  ruleset.json              # Branch protection config (applied via /protect)
+  workflows/ci.yml          # CI scaffold (lint, test, build)
 CLAUDE.md                 # Project instructions (read by Claude Code)
 install.sh                # Install into target project
 ```


### PR DESCRIPTION
## Summary

- Update CHANGELOG with all features, fixes, and changes from the nest upstream reconciliation
- Update README with new skills, reviewer capabilities, and .github/ scaffold

## Changes

- Added Unreleased section to CHANGELOG.md covering 10 additions, 4 changes, and 2 fixes
- Updated README agents table (reviewer now includes gh pr comment)
- Updated README skills table (added /branch and /protect)
- Updated README project structure tree (added .github/ files and new skills)

## Test Plan

- [ ] Verify CHANGELOG entries match actual changes from PRs #2 and #3
- [ ] Verify README project structure matches actual file tree

## Notes

No code changes — documentation only.

Generated with Claude Code