### PR TITLE
docs: add session handoff for 2026-02-27

### DIFF
--- a/docs/handoff-2026-02-27T1530.md
+++ b/docs/handoff-2026-02-27T1530.md
@@ -1,0 +1,54 @@
+# Session Handoff
+
+**Date**: 2026-02-27
+**Branch**: main (clean)
+**Session Goal**: Reconcile upstream changes from `bottah/nest` into `agent-bobs`, apply branch protection, and update docs
+
+## Completed
+
+- **Issue #1** — Added default `permissions.allow`/`permissions.deny` to `.claude/settings.json` (`84c24a1`)
+- **PR #2** — Upstream reconciliation from `bottah/nest`: hooks bugfixes, new skills (`/branch`, `/protect`), `.github/` scaffold, Git-Ops workflow (`c5c2101`)
+- **PR #3** — `/review` skill auto-posts findings as PR comment; reviewer agent gets `gh pr comment` permission (`3798031`)
+- **PR #4** — CHANGELOG and README updated with all changes (`e137364`)
+- **Branch protection** — Applied `ruleset.json` to GitHub via `/protect` (ruleset ID `13340932`: squash-only, linear history, required status checks)
+- **Local branch cleanup** — Deleted `feat/upstream-reconciliation` and `feat/review-pr-comment`
+- **Nest backport issue** — Created `bottah/nest#7` for permissions backport
+- **Sync skill issue** — Created `bottah/agent-bobs#5` for `/sync` skill design
+
+## In Progress
+
+- **Nest permissions backport** — File edited locally in nest (`bottah/nest#7`) but not committed. Needs to be committed from a nest session.
+
+## Not Started
+
+- **`/sync` skill implementation** (`bottah/agent-bobs#5`) — Designed but not built
+
+## Key Decisions
+
+| Decision | Rationale | Alternatives Considered |
+|----------|-----------|------------------------|
+| Generalize `.github/ci.yml` as TODO scaffold | agent-bobs is language-agnostic; nest's Go/Docker jobs don't belong | Copy nest CI verbatim |
+| Generalize `ruleset.json` to `lint` + `unit-tests` only | Nest-specific checks (validate-contract, governance) aren't generic | Keep all 6 nest status checks |
+| Use `[^/.]+` instead of `[^/]+?` in sed regex | macOS sed doesn't support non-greedy `?` | Require GNU sed |
+| Auto-detect `-R owner/repo` in skills instead of hardcoding | Template must work for any repo, not just `bottah/nest` | Hardcode per-project |
+| Cross-repo backports via GH issues, not direct edits | `path-protector.sh` correctly blocks out-of-project writes | Bypass path protector |
+
+## Current State
+
+- **Tests**: No test suite configured (CI scaffold has TODOs)
+- **Uncommitted changes**: None (main is clean)
+- **Known issues**: Nest has an uncommitted `settings.json` edit from this session — needs `bottah/nest#7`
+
+## Next Steps
+
+1. Commit nest permissions from a nest session (`bottah/nest#7`)
+2. Implement `/sync` skill (`bottah/agent-bobs#5`) — the first real test case is syncing nest
+3. Configure CI jobs in `.github/workflows/ci.yml` if/when agent-bobs gets tests
+4. Consider adding `Bash(go *)`, `Bash(cargo *)` etc. as documented examples in `settings.json` comments
+
+## Context & References
+
+- `bottah/agent-bobs#1` — Permissions issue (closed)
+- `bottah/agent-bobs#5` — `/sync` skill design (open)
+- `bottah/nest#7` — Permissions backport (open)
+- Dogfood findings: `tool-policy.json` blocked push to main, `security-gate.sh` blocked `git reset --hard` in heredoc body text, macOS sed broke non-greedy regex


### PR DESCRIPTION
## Summary

- Add handoff document capturing the upstream reconciliation session

## Changes

- `docs/handoff-2026-02-27T1530.md`: session handoff covering permissions, Git-Ops workflow, review auto-post, branch protection, and /sync skill design

## Test Plan

- [ ] Verify handoff doc accurately reflects session work

## Notes

Documentation only — no code changes.

Generated with Claude Code