### PR TITLE
feat: block --admin flag on gh pr merge in tool-policy

### DIFF
--- a/scripts/hooks/tool-policy.json
+++ b/scripts/hooks/tool-policy.json
@@ -14,6 +14,11 @@
       "match": "^git push\\s*$",
       "mode": "regex",
       "message": "Bare git push without an explicit branch target is blocked. Specify the remote and branch: git push origin <branch-name>"
+    },
+    {
+      "match": "^gh pr merge.*--admin",
+      "mode": "regex",
+      "message": "The --admin flag bypasses all branch protection rules. If status checks are pending, wait for them to complete. If checks are failing, fix the underlying issue."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Prevent the agent from bypassing branch protection via `gh pr merge --admin`

## Changes

- Added regex rule to `scripts/hooks/tool-policy.json` blocking `gh pr merge.*--admin`

## Test Plan

- [ ] Run `gh pr merge 1 --admin` and verify it is blocked by tool-policy
- [ ] Run `gh pr merge 1 --squash` and verify it still works

## Notes

Closes #9. Surfaced during session 2026-02-27 when PR #7 was blocked by pending status checks and `--admin` was suggested as a workaround.

Generated with Claude Code