### PR TITLE
docs(changelog): add --admin merge block to unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Git-Ops Workflow section in `CLAUDE.md` documenting multi-layer enforcement of feature-branch development
 - Auto-post review findings as PR comment via `gh pr comment` in `/review` skill
 - Main-branch warning in `context-loader.sh` at session start
-- `tool-policy.json` rules blocking direct push to main/master
+- `tool-policy.json` rules blocking direct push to main/master and `--admin` bypass on `gh pr merge`
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- Update CHANGELOG to reflect the --admin bypass block added in PR #10

## Changes

- Updated `tool-policy.json` entry in CHANGELOG Unreleased/Added to include `--admin` merge block

## Test Plan

- [ ] Verify entry matches PR #10 changes

## Notes

Documentation only.

Generated with Claude Code