### PR TITLE
fix(path-protector): remove .claude/settings.json from protected patterns

### DIFF
--- a/scripts/hooks/path-protector.sh
+++ b/scripts/hooks/path-protector.sh
@@ -34,7 +34,6 @@ protected_patterns=(
   "credentials/*"
   "config/production/*"
   "**/secrets/*"
-  ".claude/settings.json"
 )
 
 for pattern in "${protected_patterns[@]}"; do


### PR DESCRIPTION
## Summary
- Remove `.claude/settings.json` from path-protector's protected patterns since it's intentionally committed as repo config

## Changes
- **`scripts/hooks/path-protector.sh`** — Remove `.claude/settings.json` from `protected_patterns` array

## Test Plan
- [ ] Verify Edit/Write tools can modify `.claude/settings.json` without being blocked
- [ ] Verify other protected patterns (`.env*`, `*.pem`, `*.key`, etc.) still block correctly

Closes #16

Generated with Claude Code