### PR TITLE
fix(install): exclude session artifacts from rsync

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,10 @@ exclude=(
   --exclude='install.sh'
   --exclude='.claude/audit.log'
   --exclude='.claude/settings.local.json'
+  --exclude='.claude/last-session.json'
+  --exclude='.claude/subagent.log'
+  --exclude='.claude/transcript-backups'
+  --exclude='docs/handoff-*.md'
 )
 
 # rsync preserves directory structure, only copies what changed


### PR DESCRIPTION
## Summary
- Prevent template-repo runtime artifacts from being copied into target repos during install

## Changes
- **`install.sh`** — Add 4 excludes: `.claude/last-session.json`, `.claude/subagent.log`, `.claude/transcript-backups`, `docs/handoff-*.md`

## Test Plan
- [ ] Run `install.sh` against a test directory and verify excluded files are not copied
- [ ] Verify other template files still sync correctly

Closes #17

Generated with Claude Code