### PR TITLE
fix(install): skip project-specific files that already exist in target

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,13 +18,28 @@ TARGET="$(cd "$TARGET" && pwd)"
 
 echo "Installing agent-teams template into: $TARGET"
 
-# Everything except repo infrastructure and runtime artifacts
+# Repo infrastructure and runtime artifacts
 exclude=(
   --exclude='.git'
   --exclude='install.sh'
   --exclude='.claude/audit.log'
   --exclude='.claude/settings.local.json'
 )
+
+# Project-specific files that are customized after initial install.
+# Only copy these if they don't already exist in the target.
+customize_once=(
+  README.md
+  CHANGELOG.md
+  .github/workflows/ci.yml
+  .github/ruleset.json
+)
+
+for f in "${customize_once[@]}"; do
+  if [[ -e "$TARGET/$f" ]]; then
+    exclude+=(--exclude="$f")
+  fi
+done
 
 # rsync preserves directory structure, only copies what changed
 rsync -a "${exclude[@]}" "$SCRIPT_DIR/" "$TARGET/"


### PR DESCRIPTION
## Summary
- Prevent `install.sh` from overwriting project-specific files on re-install, while still copying them on first install

## Changes
- **`install.sh`** — Add `customize_once` array listing files that should only be copied if they don't already exist in the target (`README.md`, `CHANGELOG.md`, `ci.yml`, `ruleset.json`). Dynamically adds them to the rsync exclude list when present.

## Test Plan
- [ ] First install into empty dir: all files including customize-once files are copied
- [ ] Re-install into same dir: customize-once files are skipped, managed files are updated
- [ ] Adding a new hook script to template and re-installing: new hook appears in target

## Notes
- This is the lightweight version of option 1 from the issue. A full init/update two-mode install (option 3) can be added later if needed.
- Related: #17 addresses session artifact excludes separately

Closes #18

Generated with Claude Code