### PR TITLE
fix(auto-allow-reads): fix gh subcommand matching and add pr checks/diff

### DIFF
--- a/scripts/hooks/auto-allow-reads.sh
+++ b/scripts/hooks/auto-allow-reads.sh
@@ -54,9 +54,9 @@ if [ "$tool_name" = "Bash" ] && [ -n "$command" ]; then
       ;;
     gh)
       # Only allow read operations
-      gh_subcmd=$(echo "$command" | sed 's/^gh //' | awk '{print $1}')
+      gh_subcmd=$(echo "$command" | sed 's/^gh //' | awk '{print $1, $2}')
       case "$gh_subcmd" in
-        pr\ view|pr\ list|issue\ view|issue\ list|api|repo\ view|run\ list|run\ view)
+        pr\ view|pr\ list|pr\ checks|pr\ diff|issue\ view|issue\ list|repo\ view|run\ list|run\ view)
           echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
           exit 0
         ;;


### PR DESCRIPTION
## Summary
- Fix broken gh subcommand matching in auto-allow-reads hook — no `gh` read commands were being auto-allowed
- Add `pr checks` and `pr diff` to the safe list

## Changes
- **`scripts/hooks/auto-allow-reads.sh`** — Extract two words for `gh_subcmd` (`awk '{print $1, $2}'`), add `pr checks` and `pr diff` to safe patterns, remove `api` (can't distinguish read vs write)

## Test Plan
- [ ] `gh pr checks` no longer prompts for permission
- [ ] `gh pr view`, `gh issue list`, etc. are auto-allowed
- [ ] `gh pr merge`, `gh pr create`, `gh issue create` still require permission
- [ ] `gh api -X DELETE ...` still requires permission

Closes #24

Generated with Claude Code