### PR TITLE
fix(skills): repo extraction regex breaks dotted repo names

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -47,7 +47,7 @@ Create or update a pull request using the `gh` CLI.
      ```
      remote_url=$(git remote get-url origin)
      # Extract owner/repo from SSH or HTTPS URL
-     repo=$(echo "$remote_url" | sed -E 's|.*[:/]([^/]+/[^/.]+)(\.git)?$|\1|')
+     repo=$(echo "$remote_url" | sed -E 's|(\.git)$||; s|.*[:/]([^/]+/[^/]+)$|\1|')
      gh pr create -R "$repo" --title "..." --body "..."
      ```
 9. Show the PR URL to the user

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -50,7 +50,7 @@ The user may provide:
 ```
 
 6. **Post to PR**: If the review is for a PR (PR number given, or the current branch has an open PR), post the review as a PR comment:
-   - Auto-detect repo: `repo=$(git remote get-url origin | sed -E 's|.*[:/]([^/]+/[^/.]+)(\.git)?$|\1|')`
+   - Auto-detect repo: `repo=$(git remote get-url origin | sed -E 's|(\.git)$||; s|.*[:/]([^/]+/[^/]+)$|\1|')`
    - Detect open PR: `gh pr view --json number -q .number -R "$repo" 2>/dev/null`
    - Post comment: `gh pr comment <number> -R "$repo" --body "<review>"` (use a HEREDOC for the body)
    - If no PR is associated, just output the review to the terminal


### PR DESCRIPTION
## Summary
- Fix repo extraction regex in `/pr` and `/review` skills that rejected dots in repo names (e.g., `owner/my.project.git`)

## Changes
- **`.claude/skills/pr/SKILL.md`** — Strip `.git` suffix first, then extract `owner/repo` with dot-permissive pattern
- **`.claude/skills/review/SKILL.md`** — Same fix

## Test Plan
- [ ] `owner/repo.git` → `owner/repo`
- [ ] `owner/repo.name.git` → `owner/repo.name`
- [ ] `owner/repo` (no .git suffix) → `owner/repo`

Closes #28

Generated with Claude Code