### PR TITLE
fix(hooks): remove env/printenv from auto-allow-reads safe list

### DIFF
--- a/scripts/hooks/auto-allow-reads.sh
+++ b/scripts/hooks/auto-allow-reads.sh
@@ -30,7 +30,7 @@ if [ "$tool_name" = "Bash" ] && [ -n "$command" ]; then
 
   # Safe read-only commands
   case "$base_cmd" in
-    ls|cat|head|tail|wc|file|which|whoami|pwd|date|uname|env|printenv)
+    ls|cat|head|tail|wc|file|which|whoami|pwd|date|uname)
       echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
       exit 0
       ;;


### PR DESCRIPTION
## Summary
- Remove `env` and `printenv` from auto-allow-reads to resolve conflict with security-gate's secret leakage protection

## Changes
- **`scripts/hooks/auto-allow-reads.sh`** — Remove `env` and `printenv` from safe command list

## Test Plan
- [ ] `env` and `printenv` now prompt for permission instead of being auto-allowed
- [ ] Other safe commands (`ls`, `pwd`, `date`, etc.) still auto-allow
- [ ] `security-gate.sh` continues to block bare env/printenv after manual approval

Closes #29

Generated with Claude Code