### PR TITLE
fix(install): add CLAUDE.md to customize_once list

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,7 @@ exclude=(
 customize_once=(
   README.md
   CHANGELOG.md
+  CLAUDE.md
   .github/workflows/ci.yml
   .github/ruleset.json
 )


### PR DESCRIPTION
## Summary
- Prevent `install.sh` from overwriting project-specific CLAUDE.md content on re-install

## Changes
- **`install.sh`** — Add `CLAUDE.md` to the `customize_once` array

## Test Plan
- [ ] First install: CLAUDE.md is copied
- [ ] Re-install: CLAUDE.md is skipped, project-specific dev commands preserved

Closes #27

Generated with Claude Code