### PR TITLE
fix(install): use consistent project name in installer output

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ fi
 
 TARGET="$(cd "$TARGET" && pwd)"
 
-echo "Installing agent-teams template into: $TARGET"
+echo "Installing agent-bobs template into: $TARGET"
 
 # Repo infrastructure and runtime artifacts
 exclude=(


### PR DESCRIPTION
## Summary
- Replace stale `agent-teams` name in install.sh output with `agent-bobs` to match the repo

## Changes
- **`install.sh`** — `"Installing agent-teams template"` → `"Installing agent-bobs template"`

## Test Plan
- [ ] Run `install.sh` and verify output says `agent-bobs`

Closes #15

Generated with Claude Code