### PR TITLE
fix(review): make repo extraction step 1 to fix PR detection

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -18,15 +18,20 @@ The user may provide:
 
 ## Steps
 
-1. Determine the scope of review:
-   - If a PR number is given: `gh pr diff <number>`
+1. **Extract repo identifier** (required — SSH aliases prevent `gh` auto-detection):
+   ```bash
+   repo=$(git remote get-url origin | sed -E 's|(\.git)$||; s|.*[:/]([^/]+/[^/]+)$|\1|')
+   ```
+   Use `-R "$repo"` on **every** `gh` command in this skill.
+2. Determine the scope of review:
+   - If a PR number is given: `gh pr diff <number> -R "$repo"`
    - If a git range is given: `git diff <range>`
    - If a file/glob is given: read those files
    - If nothing: `git diff` (staged + unstaged)
-2. Read the checklist from `checklist.md`
-3. Check for a `REVIEW_GUIDELINES.md` file in the repository root. If it exists, read it and apply its project-specific criteria **in addition to** the built-in checklist. Project guidelines take precedence when they conflict with the default checklist.
-4. For each checklist category, evaluate the code and note findings
-5. Produce a structured review report:
+3. Read the checklist from `checklist.md`
+4. Check for a `REVIEW_GUIDELINES.md` file in the repository root. If it exists, read it and apply its project-specific criteria **in addition to** the built-in checklist. Project guidelines take precedence when they conflict with the default checklist.
+5. For each checklist category, evaluate the code and note findings
+6. Produce a structured review report:
 
 ```
 ## Review Summary
@@ -49,8 +54,7 @@ The user may provide:
 | ... | pass/warn/fail | ... |
 ```
 
-6. **Post to PR**: If the review is for a PR (PR number given, or the current branch has an open PR), post the review as a PR comment:
-   - Auto-detect repo: `repo=$(git remote get-url origin | sed -E 's|(\.git)$||; s|.*[:/]([^/]+/[^/]+)$|\1|')`
+7. **Post to PR**: If the review is for a PR (PR number given, or the current branch has an open PR), post the review as a PR comment:
    - Detect open PR: `gh pr view --json number -q .number -R "$repo" 2>/dev/null`
    - Post comment: `gh pr comment <number> -R "$repo" --body "<review>"` (use a HEREDOC for the body)
    - If no PR is associated, just output the review to the terminal


### PR DESCRIPTION
## Summary
- Fix /review skill failing to detect open PRs on SSH alias remotes by making repo extraction a mandatory first step

## Changes
- **`.claude/skills/review/SKILL.md`** — Move repo extraction from step 6 to step 1 with bold "required" callout; add `-R "$repo"` to all `gh` commands including `gh pr diff`; remove redundant auto-detect line from former step 6; renumber steps

## Test Plan
- [ ] Run `/review` on a branch with an open PR — review should auto-post as PR comment
- [ ] Run `/review` on a branch without a PR — review should output to terminal
- [ ] Verify `-R` flag is used on all `gh` commands in the skill

Closes #6

Generated with Claude Code