### PR TITLE
feat(ruleset): require 1 approving review on main

### DIFF
--- a/.github/ruleset.json
+++ b/.github/ruleset.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Branch protection ruleset applied via /protect skill. Edit this file and re-run /protect to update. Note: required_approving_review_count is 0 because GitHub does not allow self-approval — solo devs cannot satisfy a review requirement.",
+  "_comment": "Branch protection ruleset applied via /protect skill. Edit this file and re-run /protect to update. Reviews are submitted by the dedicated reviewer account (talosaether) via gh-review.sh.",
   "ruleset": {
     "name": "main-protection",
     "target": "branch",
@@ -14,7 +14,7 @@
       {
         "type": "pull_request",
         "parameters": {
-          "required_approving_review_count": 0,
+          "required_approving_review_count": 1,
           "dismiss_stale_reviews_on_push": true,
           "require_code_owner_review": false,
           "require_last_push_approval": false,


### PR DESCRIPTION
## Summary
- Bump `required_approving_review_count` from `0` to `1` now that `talosaether` is a collaborator and `gh-review.sh` submits formal reviews as a separate identity
- This is the integration test for PR #46 — if this PR can be approved and merged via the new review gate, the system works end-to-end

## Changes
- `.github/ruleset.json`: `required_approving_review_count`: `0` → `1`
- Updated `_comment` to reference dedicated reviewer account

## Test Plan
- [ ] After merge, run `/protect` to apply the ruleset to GitHub
- [ ] Verify a subsequent PR requires 1 approving review to merge

## Notes
- Depends on #46 (merged)
- After merge, run `/protect` to push the ruleset to GitHub

Generated with Claude Code