### PR TITLE
feat(hooks): detect unapplied/stale ruleset at session start

### DIFF
--- a/scripts/hooks/context-loader.sh
+++ b/scripts/hooks/context-loader.sh
@@ -9,6 +9,7 @@ if ! git rev-parse --is-inside-work-tree &>/dev/null; then
 fi
 
 context=""
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Current branch
 branch=$(git branch --show-current 2>/dev/null)
@@ -57,8 +58,46 @@ if command -v bd &>/dev/null; then
   fi
 fi
 
+# Ruleset drift check (if .github/ruleset.json exists)
+ruleset_file="$repo_root/.github/ruleset.json"
+if [ -f "$ruleset_file" ] && command -v gh &>/dev/null && command -v jq &>/dev/null; then
+  repo=$(git remote get-url origin 2>/dev/null | sed -E 's|(\.git)$||; s|.*[:/]([^/]+/[^/]+)$|\1|')
+  if [ -n "$repo" ]; then
+    local_name=$(jq -r '.ruleset.name // empty' "$ruleset_file" 2>/dev/null)
+    if [ -n "$local_name" ]; then
+      # Fetch remote rulesets (fail open — skip silently on auth or network errors)
+      remote_rulesets=$(gh api "repos/$repo/rulesets" 2>/dev/null) || remote_rulesets=""
+      if [ -n "$remote_rulesets" ]; then
+        remote_match=$(echo "$remote_rulesets" | jq -r --arg name "$local_name" '[.[] | select(.name == $name)] | first // empty' 2>/dev/null)
+        if [ -z "$remote_match" ] || [ "$remote_match" = "null" ]; then
+          context+="WARNING: .github/ruleset.json defines '$local_name' but no matching GitHub ruleset found. Run /protect to apply.\n"
+        else
+          # Compare key parameters: required_approving_review_count and enforcement
+          remote_id=$(echo "$remote_match" | jq -r '.id' 2>/dev/null)
+          remote_detail=$(gh api "repos/$repo/rulesets/$remote_id" 2>/dev/null) || remote_detail=""
+          if [ -n "$remote_detail" ]; then
+            local_review_count=$(jq -r '.ruleset.rules[]? | select(.type == "pull_request") | .parameters.required_approving_review_count // empty' "$ruleset_file" 2>/dev/null)
+            remote_review_count=$(echo "$remote_detail" | jq -r '.rules[]? | select(.type == "pull_request") | .parameters.required_approving_review_count // empty' 2>/dev/null)
+            local_enforcement=$(jq -r '.ruleset.enforcement // empty' "$ruleset_file" 2>/dev/null)
+            remote_enforcement=$(echo "$remote_detail" | jq -r '.enforcement // empty' 2>/dev/null)
+            drift=""
+            if [ -n "$local_review_count" ] && [ -n "$remote_review_count" ] && [ "$local_review_count" != "$remote_review_count" ]; then
+              drift+="required_approving_review_count: local=$local_review_count, remote=$remote_review_count; "
+            fi
+            if [ -n "$local_enforcement" ] && [ -n "$remote_enforcement" ] && [ "$local_enforcement" != "$remote_enforcement" ]; then
+              drift+="enforcement: local=$local_enforcement, remote=$remote_enforcement; "
+            fi
+            if [ -n "$drift" ]; then
+              context+="WARNING: GitHub ruleset '$local_name' differs from .github/ruleset.json — ${drift}Run /protect to sync.\n"
+            fi
+          fi
+        fi
+      fi
+    fi
+  fi
+fi
+
 # Previous session context (written by session-cleanup.sh)
-repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 last_session="$repo_root/.claude/last-session.json"
 if [ -f "$last_session" ]; then
   prev_branch=$(jq -r '.branch // empty' "$last_session" 2>/dev/null)


### PR DESCRIPTION
## Summary
- Add ruleset drift detection to `context-loader.sh` so Claude warns at session start if `.github/ruleset.json` is unapplied or out of sync with GitHub

## Changes
- `scripts/hooks/context-loader.sh`: new ruleset check block between beads status and previous session context
  - If no matching GitHub ruleset exists: warns to run `/protect`
  - If ruleset exists but key params differ (review count, enforcement): warns with specific drift details
  - Fails open on auth/network errors
  - Moved `repo_root` assignment earlier (used by both ruleset check and previous session block)

## Test Plan
- [x] `bash -n` syntax check passes
- [x] No false warnings when local and remote are in sync
- [x] Correctly detects drift when local `required_approving_review_count` differs from remote
- [x] Execution time ~630ms (two `gh api` calls)

## Notes
- Closes #48

Generated with Claude Code